### PR TITLE
Fix mt_pre_trans_scale incorporating colData incorrectly

### DIFF
--- a/maplet/R/mt_pre_trans_scale.R
+++ b/maplet/R/mt_pre_trans_scale.R
@@ -37,6 +37,8 @@ mt_pre_trans_scale <- function(D, center_data=T, scale_data=T, ref_samples) {
 
     # get and filter
     Da_filtered <- t(assay(D))[samples.used,]
+    # Reset Da to not include colData
+    Da <- t(assay(D))
 
     if(center_data == T){
       # center by mean of selected samples


### PR DESCRIPTION
When specifying reference samples in `mt_pre_trans_scale`, colData is left in the Da matrix so that when the values are transformed, it will end up also attempting to transform colData values (which will lead to errors when the column has non-numeric values).

So I have simply reset Da after reference samples have been selected from the experiment.